### PR TITLE
Mac users need to install `armadillo`

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -44,6 +44,12 @@ In order to compile the `C++` in this package, `RcppArmadillo` will require you 
 xcode-select --install
 ```
 
+You may need to install the `armadillo` software to compile the package. This can be done using [the Homebrew package manager](https://brew.sh/).
+
+```bash
+brew install armadillo
+```
+
 If you are having problems with this install on Mac OSX, specifically if you are getting errors with either `lgfortran` or `lquadmath`, then try open your Terminal and try the following:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ have these, but you can install them by running:
 xcode-select --install
 ```
 
+You may need to install the `armadillo` software to compile the package. This can be done using [the Homebrew package manager](https://brew.sh/).
+
+```bash
+brew install armadillo
+```
+
 If you are having problems with this install on Mac OSX, specifically if
 you are getting errors with either `lgfortran` or `lquadmath`, then try
 open your Terminal and try the following:


### PR DESCRIPTION
I was unable to install the package at first because I didn't have the `armadillo` package installed. This can be done easily with Homebrew.

This PR adds a note to the README about it.


